### PR TITLE
InvalidArgumentException when version param not passed

### DIFF
--- a/inc/class-ses.php
+++ b/inc/class-ses.php
@@ -147,7 +147,9 @@ class SES {
 	public function get_client() {
 		require_once dirname( dirname( __FILE__ ) ) . '/lib/aws-sdk/aws-autoloader.php';
 
-		$params = array();
+		$params = array(
+			'version' => '2010-12-01',
+		);
 
 		if ( $this->key && $this->secret ) {
 			$params['key'] = $this->key;


### PR DESCRIPTION
make sure SDK version is passed along with request to avoid InvalidArgumentException when called via CLI