### PR TITLE
Add $message_args to aws_ses_wp_mail_ses_send_message_args filter

### DIFF
--- a/inc/class-ses.php
+++ b/inc/class-ses.php
@@ -142,7 +142,7 @@ class SES {
 				);
 			}
 
-			$args = apply_filters( 'aws_ses_wp_mail_ses_send_message_args', $args );
+			$args = apply_filters( 'aws_ses_wp_mail_ses_send_message_args', $args, $message_args );
 
 			$ses->sendEmail( $args );
 		} catch ( \Exception $e ) {


### PR DESCRIPTION
This adds the $message_args to the aws_ses_wp_mail_ses_send_message_args filter as a second paramater.  Currently, there is no way to access any of the headers passed to `wp_mail` such as for carbon copies, this enables it. 