### PR TITLE
Unset header before setting a new one

### DIFF
--- a/inc/class-ses.php
+++ b/inc/class-ses.php
@@ -69,9 +69,9 @@ class SES {
 		// transform headers array into a key => value map
 		foreach ( $headers as $header => $value ) {
 			if ( strpos( $value, ':' ) ) {
+				unset( $headers[ $header ] );
 				$value = array_map( 'trim', explode( ':', $value ) );
 				$headers[ $value[0] ] = $value[1];
-				unset( $headers[ $header ] );
 			}
 		}
 


### PR DESCRIPTION
This appears to be enough to take care of #20. The loop was reformatting the array of headers and then unsetting each one resulting in an empty array.

With this fixed, the `ucwords` loop seems to get the job done as far as case matching is concerned, at least in the limited test that I ran. Feel free to ignore this if you have a more elegant solution in mind.