### PR TITLE
Switch to credentials param

### DIFF
--- a/inc/class-ses.php
+++ b/inc/class-ses.php
@@ -175,8 +175,10 @@ class SES {
 		);
 
 		if ( $this->key && $this->secret ) {
-			$params['key'] = $this->key;
-			$params['secret'] = $this->secret;
+			$params['credentials'] = array(
+				'key'    => $this->key,
+				'secret' => $this->secret,
+			);
 		}
 
 		if ( $this->region ) {


### PR DESCRIPTION
So apparently the `token` key isn't necessarily needed but on local dev without an `.aws/credentials` file it breaks all altogether.

Related: #12