### PR TITLE
Support Reply To, CC and BCC

### DIFF
--- a/inc/class-ses.php
+++ b/inc/class-ses.php
@@ -155,6 +155,11 @@ class SES {
 				);
 			}
 
+			if ( ! empty( $message_args['headers']['Reply-To'] ) ) {
+				$replyto = explode( ',', $message_args['headers']['Reply-To'] );
+				$args['ReplyToAddresses'] = array_map( 'trim', $replyto );
+			}
+
 			$args = apply_filters( 'aws_ses_wp_mail_ses_send_message_args', $args, $message_args );
 			$ses->sendEmail( $args );
 		} catch ( Exception $e ) {

--- a/inc/class-ses.php
+++ b/inc/class-ses.php
@@ -79,7 +79,7 @@ class SES {
 
 		// normalize header names to Camel-Case
 		foreach ( $headers as $name => $value ) {
-			$uc_name = ucwords( $name, '-' );
+			$uc_name = ucwords( strtolower( $name ), '-' );
 			if ( $uc_name !== $name ) {
 				$headers[ $uc_name ] = $value;
 				unset( $headers[ $name ] );

--- a/inc/class-ses.php
+++ b/inc/class-ses.php
@@ -160,6 +160,15 @@ class SES {
 				$args['ReplyToAddresses'] = array_map( 'trim', $replyto );
 			}
 
+			foreach ( [ 'Cc', 'Bcc'] as $type ) {
+				if ( empty( $message_args['headers'][ $type ] ) ) {
+					continue;
+				}
+
+				$addrs = explode( ',', $message_args['headers'][ $type ] );
+				$args['Destination'][ $type . 'Addresses' ] = array_map( 'trim', $addrs );
+			}
+
 			$args = apply_filters( 'aws_ses_wp_mail_ses_send_message_args', $args, $message_args );
 			$ses->sendEmail( $args );
 		} catch ( Exception $e ) {

--- a/inc/class-wp-cli-command.php
+++ b/inc/class-wp-cli-command.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace AWS_SES_WP_Mail;
+
 use WP_CLI;
 use WP_Error;
 
@@ -12,7 +13,26 @@ class WP_CLI_Command extends \WP_CLI_Command {
 	/**
 	 * Send an email via AWS SES
 	 *
-	 * @synopsis <to-email> <subject> <message> [--from-email=<from-email>]
+	 * <to-email>
+	 * : Email address to send to.
+	 *
+	 * <subject>
+	 * : Email subject.
+	 *
+	 * <message>
+	 * : Email message.
+	 *
+	 * [--from-email=<from-email>]
+	 * : Email address to send from.
+	 *
+	 * [--reply-to=<reply-to>]
+	 * : Email address to set as Reply-To.
+	 *
+	 * [--cc=<cc>]
+	 * : Email addresses to CC (comma-separated).
+	 *
+	 * [--bcc=<bcc>]
+	 * : Email addresses to BCC (comma-separated).
 	 */
 	public function send( $args, $args_assoc ) {
 
@@ -21,7 +41,19 @@ class WP_CLI_Command extends \WP_CLI_Command {
 				return $args_assoc['from-email'];
 			});
 		}
-		$result = SES::get_instance()->send_wp_mail( $args[0], $args[1], $args[2] );
+
+		$headers = [];
+		if ( ! empty( $args_assoc['reply-to'] ) ) {
+			$headers['Reply-To'] = $args_assoc['reply-to'];
+		}
+		if ( ! empty( $args_assoc['cc'] ) ) {
+			$headers['CC'] = $args_assoc['cc'];
+		}
+		if ( ! empty( $args_assoc['bcc'] ) ) {
+			$headers['BCC'] = $args_assoc['bcc'];
+		}
+
+		$result = SES::get_instance()->send_wp_mail( $args[0], $args[1], $args[2], $headers );
 
 		if ( is_wp_error( $result ) ) {
 			WP_CLI::error( $result->get_error_code() . ': ' . $result->get_error_message() );


### PR DESCRIPTION
Adds support for Reply-To, CC, and BCC headers. In addition, fixes up the normalisation of the headers: `ucwords` only changes the first character, so `ucwords('xyz') -> Xyz` but `ucwords('xyZ') -> XyZ`. By lowercasing first, this ensures consistency.

Also adds support for all of these to the test command.

Fixes #7.