### PR TITLE
Quote the from name by default

### DIFF
--- a/inc/class-ses.php
+++ b/inc/class-ses.php
@@ -107,7 +107,7 @@ class SES {
 			'to'                         => $to,
 			'headers'                    => array(
 				'Content-Type'           => apply_filters( 'wp_mail_content_type', 'text/plain' ),
-				'From'                   => sprintf( '%s <%s>', apply_filters( 'wp_mail_from_name', get_bloginfo( 'name' ) ), apply_filters( 'wp_mail_from', $from_email ) ),
+				'From'                   => sprintf( '"%s" <%s>', apply_filters( 'wp_mail_from_name', get_bloginfo( 'name' ) ), apply_filters( 'wp_mail_from', $from_email ) ),
 			),
 		);
 		$message_args['headers'] = array_merge( $message_args['headers'], $headers );


### PR DESCRIPTION
Currently if you have a site with something like `&amp;` in the title, it will error sending email, as the Name is not escaped.