### PR TITLE
Update from email to be no-reply@sitename

### DIFF
--- a/inc/class-ses.php
+++ b/inc/class-ses.php
@@ -99,7 +99,7 @@ class SES {
 			$sitename = substr( $sitename, 4 );
 		}
 
-		$from_email = 'wordpress@' . $sitename;
+		$from_email = 'no-reply@' . $sitename;
 
 		$message_args = array(
 			// Email


### PR DESCRIPTION
`wordpress@` exposes the site as a WordPress site. `no-reply@` hides that as well as signifies this is a no-response email.