### PR TITLE
Allow for plugin to use Amazon SDK directly. Clarify installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,21 @@
 
 AWS SES is a very simple UI-less plugin for sending `wp_mail()`s email via AWS SES.
 
-Getting Set Up
+Installation
 ==========
 
-Once you have `git clone`d the repo, or added it as a Git Submodule, add the following constants to your `wp-config.php`:
+The ideal approach for using this plugin is to install it via composer at the root of your project. This can prevent multiple versions of the Amazon SDK from being installed within your codebase. 
+
+```
+composer require humanmade/aws-ses-wp-mail
+```
+
+Otherwise, clone the plugin to  `/wp-content/plugins` and then run `composer install` within the resulting directory. 
+
+Configuration
+==========
+
+Once installed, add the following constants to your `wp-config.php`:
 
 ```PHP
 define( 'AWS_SES_WP_MAIL_REGION', 'us-east-1' );

--- a/aws-ses-wp-mail.php
+++ b/aws-ses-wp-mail.php
@@ -14,6 +14,12 @@ if ( ( ! defined( 'AWS_SES_WP_MAIL_KEY' ) || ! defined( 'AWS_SES_WP_MAIL_SECRET'
 	return;
 }
 
+// Access to the Amazon SDK is required for this plugin to send mail.
+// It can be provided directly via composer install within this plugin, or as a dependency of your project.
+if ( is_readable( dirname( __FILE__ ) . '/vendor/autoload.php' ) ) {
+	require_once dirname( __FILE__ ) . '/vendor/autoload.php';
+}
+
 require_once dirname( __FILE__ ) . '/inc/class-ses.php';
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {


### PR DESCRIPTION
Putting this together from various comments and PRs for the project. This PR will.

- Allow for the use of the plugin via direct `git clone` and `composer install` mechanisms.
- Strongly suggest that the best way to use this plugin is to install it at the root of your project to prevent duplicate copies of the Amazon SDK from entering the codebase.

The solution to allow for both mechanisms to be used comes from [this comment](https://github.com/humanmade/aws-ses-wp-mail/pull/44#discussion_r748254812) in the open PR #44. 

The language included in the README file is borrowed from the [commentary for issue #43](https://github.com/humanmade/aws-ses-wp-mail/issues/43#issuecomment-967077649).