### PR TITLE
Support composer/installers 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "type": "wordpress-plugin",
   "require": {
     "php": ">=5.3",
-    "composer/installers": "~1.0 || ^2.0",
+    "composer/installers": "^1.0 || ^2.0",
     "aws/aws-sdk-php": "^3.18.0"
   }
 }


### PR DESCRIPTION
Doing the same as: https://github.com/humanmade/S3-Uploads/pull/551

> There are no WordPress-related breaking changes in 2.0, per [the changelog](https://github.com/composer/installers/releases/tag/v2.0.0).