### PR TITLE
Allow a colon in the name in the From header

### DIFF
--- a/inc/class-ses.php
+++ b/inc/class-ses.php
@@ -74,7 +74,7 @@ class SES {
 		// transform headers array into a key => value map
 		foreach ( $headers as $header => $value ) {
 			if ( strpos( $value, ':' ) ) {
-				$value = array_map( 'trim', explode( ':', $value ) );
+				$value = array_map( 'trim', explode( ':', $value, 2 ) );
 				$headers[ $value[0] ] = $value[1];
 
 				// Gravity Forms uses an array like


### PR DESCRIPTION
Having a site name like "Foo: Bar" currently results in a malformed From header `From: "Foo` which ultimately fails delivery at SES. This change limits the split to only the first colon character. This is in line with Core's behavior:

https://github.com/WordPress/WordPress/blob/b691849290207fa01e439f8db6cd09091f62b394/wp-includes/pluggable.php#L291-L292