### PR TITLE
Adds support for SESv2 and SES tenant isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,22 @@ Once you have verified your sending domain, you are all good to go!
 
 ### Configuration Sets
 
-To better track your mail activity for monitoring or statistics you can use the configuration sets. To enable it you will first need to create your Configuration Set on AWS SES Console and add the configuration set name as the value to the `AWS_SES_WP_MAIL_CONFIG_SET` constant. 
+To better track your mail activity for monitoring or statistics you can use the configuration sets. To enable it you will first need to create your Configuration Set on AWS SES Console and add the configuration set name as the value to the `AWS_SES_WP_MAIL_CONFIG_SET` constant.
 
 Detailed information on the setup and usage you find here: https://docs.aws.amazon.com/ses/latest/DeveloperGuide/using-configuration-sets.html
+
+### SESv2 and Tenant Isolation
+
+This plugin automatically uses the **AWS SESv2 API** when `Aws\SesV2\SesV2Client` is available in the installed SDK (requires `aws/aws-sdk-php >= 3.133`), falling back to SESv1 for older SDK versions.
+
+To route sends through an SESv2 tenant (for reputation isolation and per-tenant statistics), set the tenant name constant:
+
+```PHP
+define( 'AWS_SES_WP_MAIL_TENANT_NAME', 'your-tenant-name' );
+```
+
+**IAM permissions:** When using SESv2, your IAM policy must include `sesv2:SendEmail` in addition to the existing `ses:SendEmail` action. The policy resources should include your identity ARNs, configuration set ARN, and tenant ARN.
+
 
 Other Commands
 =======

--- a/inc/class-ses.php
+++ b/inc/class-ses.php
@@ -3,6 +3,7 @@
 namespace AWS_SES_WP_Mail;
 
 use Aws\Ses\SesClient;
+use Aws\SesV2\SesV2Client;
 use Exception;
 use WP_Error;
 
@@ -13,6 +14,7 @@ class SES {
 	private $secret;
 	private $config_set;
 	private $client;
+	private $use_v2 = false;
 
 	/**
 	 *
@@ -133,12 +135,11 @@ class SES {
 		$from_name = apply_filters( 'wp_mail_from_name', get_bloginfo( 'name' ) );
 
 		$message_args = [
-			// Email
-			'subject'                    => $subject,
-			'to'                         => $to,
-			'headers'                    => [
-				'Content-Type'           => apply_filters( 'wp_mail_content_type', 'text/plain' ),
-				'From'                   => sprintf( '"%s" <%s>', mb_encode_mimeheader( $from_name ), $from_email ),
+			'subject'  => $subject,
+			'to'       => $to,
+			'headers'  => [
+				'Content-Type' => apply_filters( 'wp_mail_content_type', 'text/plain' ),
+				'From'         => sprintf( '"%s" <%s>', mb_encode_mimeheader( $from_name ), $from_email ),
 			],
 		];
 		$message_args['headers'] = array_merge( $message_args['headers'], $headers );
@@ -155,7 +156,7 @@ class SES {
 			$message_args['html'] = $message;
 		}
 
-		// Allow user to override message args before they're sent to Mandrill.
+		// Allow user to override message args before they're sent.
 		$message_args = apply_filters( 'aws_ses_wp_mail_message_args', $message_args );
 
 		$ses = $this->get_client();
@@ -165,50 +166,10 @@ class SES {
 		}
 
 		try {
-			$args = [
-				'Source'      => $message_args['headers']['From'],
-				'Destination' => [
-					'ToAddresses' => $message_args['to'],
-				],
-				'Message'     => [
-					'Subject' => [
-						'Data'    => $message_args['subject'],
-						'Charset' => get_bloginfo( 'charset' ),
-					],
-					'Body'   => [],
-				],
-			];
-
-			if ( ! empty( $this->config_set ) ) {
-				$args['ConfigurationSetName'] = $this->config_set;
-			}
-
-			if ( isset( $message_args['text'] ) ) {
-				$args['Message']['Body']['Text'] = [
-					'Data'    => $message_args['text'],
-					'Charset' => get_bloginfo( 'charset' ),
-				];
-			}
-
-			if ( isset( $message_args['html'] ) ) {
-				$args['Message']['Body']['Html'] = [
-					'Data'    => $message_args['html'],
-					'Charset' => get_bloginfo( 'charset' ),
-				];
-			}
-
-			if ( ! empty( $message_args['headers']['Reply-To'] ) ) {
-				$replyto = explode( ',', $message_args['headers']['Reply-To'] );
-				$args['ReplyToAddresses'] = array_map( 'trim', $replyto );
-			}
-
-			foreach ( [ 'Cc', 'Bcc' ] as $type ) {
-				if ( empty( $message_args['headers'][ $type ] ) ) {
-					continue;
-				}
-
-				$addrs = explode( ',', $message_args['headers'][ $type ] );
-				$args['Destination'][ $type . 'Addresses' ] = array_map( 'trim', $addrs );
+			if ( $this->use_v2 ) {
+				$args = $this->build_v2_args( $message_args );
+			} else {
+				$args = $this->build_v1_args( $message_args );
 			}
 
 			$args = apply_filters( 'aws_ses_wp_mail_ses_send_message_args', $args, $message_args );
@@ -217,21 +178,139 @@ class SES {
 			$error = new WP_Error( 'wp_mail_failed', $e->getMessage() );
 
 			do_action( 'wp_mail_failed', $error, $message_args );
-
 			do_action( 'aws_ses_wp_mail_ses_error_sending_message', $e, $args, $message_args );
+
 			return new WP_Error( get_class( $e ), $e->getMessage() );
 		}
 
 		do_action( 'wp_mail_succeeded', $message_args );
-
 		do_action( 'aws_ses_wp_mail_ses_sent_message', $result, $args, $message_args );
+
 		return true;
 	}
 
 	/**
-	 * Get the client for AWS SES.
+	 * Build SESv2 SendEmail args.
 	 *
-	 * @return SesClient|WP_Error
+	 * @param array $message_args
+	 * @return array
+	 */
+	private function build_v2_args( array $message_args ) : array {
+		$charset = get_bloginfo( 'charset' );
+
+		$args = [
+			'FromEmailAddress' => $message_args['headers']['From'],
+			'Destination'      => [
+				'ToAddresses' => $message_args['to'],
+			],
+			'Content'          => [
+				'Simple' => [
+					'Subject' => [
+						'Data'    => $message_args['subject'],
+						'Charset' => $charset,
+					],
+					'Body'    => [],
+				],
+			],
+		];
+
+		if ( ! empty( $this->config_set ) ) {
+			$args['ConfigurationSetName'] = $this->config_set;
+		}
+
+		if ( isset( $message_args['text'] ) ) {
+			$args['Content']['Simple']['Body']['Text'] = [
+				'Data'    => $message_args['text'],
+				'Charset' => $charset,
+			];
+		}
+
+		if ( isset( $message_args['html'] ) ) {
+			$args['Content']['Simple']['Body']['Html'] = [
+				'Data'    => $message_args['html'],
+				'Charset' => $charset,
+			];
+		}
+
+		if ( ! empty( $message_args['headers']['Reply-To'] ) ) {
+			$replyto = explode( ',', $message_args['headers']['Reply-To'] );
+			$args['ReplyToAddresses'] = array_map( 'trim', $replyto );
+		}
+
+		foreach ( [ 'Cc', 'Bcc' ] as $type ) {
+			if ( empty( $message_args['headers'][ $type ] ) ) {
+				continue;
+			}
+
+			$addrs = explode( ',', $message_args['headers'][ $type ] );
+			$args['Destination'][ $type . 'Addresses' ] = array_map( 'trim', $addrs );
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Build SESv1 SendEmail args.
+	 *
+	 * @param array $message_args
+	 * @return array
+	 */
+	private function build_v1_args( array $message_args ) : array {
+		$charset = get_bloginfo( 'charset' );
+
+		$args = [
+			'Source'      => $message_args['headers']['From'],
+			'Destination' => [
+				'ToAddresses' => $message_args['to'],
+			],
+			'Message'     => [
+				'Subject' => [
+					'Data'    => $message_args['subject'],
+					'Charset' => $charset,
+				],
+				'Body'    => [],
+			],
+		];
+
+		if ( ! empty( $this->config_set ) ) {
+			$args['ConfigurationSetName'] = $this->config_set;
+		}
+
+		if ( isset( $message_args['text'] ) ) {
+			$args['Message']['Body']['Text'] = [
+				'Data'    => $message_args['text'],
+				'Charset' => $charset,
+			];
+		}
+
+		if ( isset( $message_args['html'] ) ) {
+			$args['Message']['Body']['Html'] = [
+				'Data'    => $message_args['html'],
+				'Charset' => $charset,
+			];
+		}
+
+		if ( ! empty( $message_args['headers']['Reply-To'] ) ) {
+			$replyto = explode( ',', $message_args['headers']['Reply-To'] );
+			$args['ReplyToAddresses'] = array_map( 'trim', $replyto );
+		}
+
+		foreach ( [ 'Cc', 'Bcc' ] as $type ) {
+			if ( empty( $message_args['headers'][ $type ] ) ) {
+				continue;
+			}
+
+			$addrs = explode( ',', $message_args['headers'][ $type ] );
+			$args['Destination'][ $type . 'Addresses' ] = array_map( 'trim', $addrs );
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Get the SES client. Prefers SESv2, falls back to SESv1.
+	 *
+	 * @return SesV2Client|SesClient|WP_Error
 	 */
 	public function get_client() {
 		if ( ! empty( $this->client ) ) {
@@ -244,7 +323,7 @@ class SES {
 
 		if ( $this->key && $this->secret ) {
 			$params['credentials'] = [
-				'key' => $this->key,
+				'key'    => $this->key,
 				'secret' => $this->secret,
 			];
 		}
@@ -268,7 +347,13 @@ class SES {
 		$params = apply_filters( 'aws_ses_wp_mail_ses_client_params', $params );
 
 		try {
-			$this->client = SesClient::factory( $params );
+			if ( class_exists( SesV2Client::class ) ) {
+				$this->client = new SesV2Client( $params );
+				$this->use_v2 = true;
+			} else {
+				$this->client = SesClient::factory( $params );
+				$this->use_v2 = false;
+			}
 		} catch ( Exception $e ) {
 			return new WP_Error( get_class( $e ), $e->getMessage() );
 		}

--- a/inc/class-ses.php
+++ b/inc/class-ses.php
@@ -13,6 +13,8 @@ class SES {
 	private $key;
 	private $secret;
 	private $config_set;
+	private $tenant_name;
+	private $region;
 	private $client;
 	private $use_v2 = false;
 
@@ -28,18 +30,20 @@ class SES {
 			$secret = defined( 'AWS_SES_WP_MAIL_SECRET' ) ? AWS_SES_WP_MAIL_SECRET : null;
 			$region = defined( 'AWS_SES_WP_MAIL_REGION' ) ? AWS_SES_WP_MAIL_REGION : null;
 			$config_set = defined( 'AWS_SES_WP_MAIL_CONFIG_SET' ) ? AWS_SES_WP_MAIL_CONFIG_SET : null;
+			$tenant_name = defined( 'AWS_SES_WP_MAIL_TENANT_NAME' ) ? AWS_SES_WP_MAIL_TENANT_NAME : null;
 
-			self::$instance = new static( $key, $secret, $region, $config_set );
+			self::$instance = new static( $key, $secret, $region, $config_set, $tenant_name );
 		}
 
 		return self::$instance;
 	}
 
-	public function __construct( $key, $secret, $region = null, $config_set = null ) {
+	public function __construct( $key, $secret, $region = null, $config_set = null, $tenant_name = null ) {
 		$this->key = $key;
 		$this->secret = $secret;
 		$this->region = $region;
 		$this->config_set = $config_set;
+		$this->tenant_name = $tenant_name;
 	}
 
 	/**
@@ -216,6 +220,10 @@ class SES {
 
 		if ( ! empty( $this->config_set ) ) {
 			$args['ConfigurationSetName'] = $this->config_set;
+		}
+
+		if ( ! empty( $this->tenant_name ) ) {
+			$args['TenantName'] = $this->tenant_name;
 		}
 
 		if ( isset( $message_args['text'] ) ) {


### PR DESCRIPTION
This pull request adds support for AWS SESv2 and tenant isolation to the plugin, while maintaining compatibility with SESv1 for older SDKs. The changes introduce logic to automatically use SESv2 if available, enable routing through SESv2 tenants for reputation isolation, and update IAM permission requirements. The codebase is refactored to handle SESv2 and SESv1 API differences, including argument building and client initialization.

**SESv2 and Tenant Isolation Support:**

- Added support for AWS SESv2 by detecting the availability of `SesV2Client` and using it when possible, falling back to SESv1 otherwise. This allows the plugin to leverage newer SES features when available. (`inc/class-ses.php`, `README.md`) [[1]](diffhunk://#diff-35e8065c36cc628da14e92517a54e2a4795b17df448580612df9bcc1871c3ed7R6) [[2]](diffhunk://#diff-35e8065c36cc628da14e92517a54e2a4795b17df448580612df9bcc1871c3ed7R358-R364) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R56-R68)
- Introduced the `AWS_SES_WP_MAIL_TENANT_NAME` constant to route emails through a specific SESv2 tenant for reputation isolation and per-tenant statistics. (`inc/class-ses.php`, `README.md`) [[1]](diffhunk://#diff-35e8065c36cc628da14e92517a54e2a4795b17df448580612df9bcc1871c3ed7R16-R19) [[2]](diffhunk://#diff-35e8065c36cc628da14e92517a54e2a4795b17df448580612df9bcc1871c3ed7R33-R46) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R56-R68)
- Updated documentation to explain SESv2 usage, tenant isolation, and updated IAM permissions required for SESv2 (`sesv2:SendEmail` in addition to `ses:SendEmail`). (`README.md`)

**Codebase Refactoring for SESv2/SESv1 Compatibility:**

- Refactored the main send logic to build and send SESv2 or SESv1 arguments as appropriate, including new methods `build_v2_args` and `build_v1_args` to handle the differences in API request structure. (`inc/class-ses.php`) [[1]](diffhunk://#diff-35e8065c36cc628da14e92517a54e2a4795b17df448580612df9bcc1871c3ed7R173-R239) [[2]](diffhunk://#diff-35e8065c36cc628da14e92517a54e2a4795b17df448580612df9bcc1871c3ed7L214-R321)
- Updated client initialization logic to prefer SESv2 and set an internal flag for which API version to use, ensuring seamless operation across different AWS SDK versions. (`inc/class-ses.php`)

These changes ensure the plugin is compatible with both SESv1 and SESv2, supports tenant isolation, and provides clear documentation for setup and required permissions.